### PR TITLE
Set the thread pool name

### DIFF
--- a/jsystemd-core/src/main/java/com/github/jpmsilva/jsystemd/Systemd.java
+++ b/jsystemd-core/src/main/java/com/github/jpmsilva/jsystemd/Systemd.java
@@ -20,6 +20,8 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.github.jpmsilva.groundlevel.utilities.StringUtilities;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -43,7 +45,9 @@ import java.util.stream.Collectors;
 public class Systemd implements AutoCloseable {
 
   private final SystemdNotify systemdNotify = SystemdUtilities.getSystemdNotify();
-  private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+  private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1, new BasicThreadFactory.Builder()
+          .namingPattern("Systemd-%d")
+          .build());
 
   private final List<SystemdNotifyStatusProvider> providers = new CopyOnWriteArrayList<>();
   private long timeout = MICROSECONDS.convert(29, SECONDS);


### PR DESCRIPTION
this is not professional, it is good practice to name threads:  
![image](https://user-images.githubusercontent.com/32991511/48690577-d511a700-ebd7-11e8-8491-6796320bb527.png)