### PR TITLE
suppress watchdog heartbeat if Spring Boot Actuator health checks are unhealthy

### DIFF
--- a/jsystemd-core/src/main/java/com/github/jpmsilva/jsystemd/HealthProvider.java
+++ b/jsystemd-core/src/main/java/com/github/jpmsilva/jsystemd/HealthProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 TomTom N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jpmsilva.jsystemd;
+
+/**
+ * A health provider can be used to control the watchdog heartbeat. An unhealthy state does not trigger the heartbeat.
+ *
+ * @author Christian Lorenz
+ */
+public interface HealthProvider {
+
+  /**
+   * @return true if application is healthy, otherwise false
+   */
+  boolean healthy();
+}

--- a/jsystemd-spring-boot-starter/pom.xml
+++ b/jsystemd-spring-boot-starter/pom.xml
@@ -52,5 +52,10 @@ limitations under the License.
       <artifactId>groundlevel-utilities</artifactId>
       <version>1.0.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/jsystemd-spring-boot-starter/src/main/java/com/github/jpmsilva/jsystemd/PendingHealthProvider.java
+++ b/jsystemd-spring-boot-starter/src/main/java/com/github/jpmsilva/jsystemd/PendingHealthProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 TomTom N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jpmsilva.jsystemd;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link HealthProvider} that suppresses/delays the unhealthy state of a delegate for a configurable period.
+ *
+ * @author Christian Lorenz
+ */
+public class PendingHealthProvider implements HealthProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PendingHealthProvider.class);
+
+  private final HealthProvider delegate;
+  /**
+   * [ms]
+   */
+  private final long pendingMs;
+  private Instant unhealthySince;
+
+  /**
+   * @param pendingMs [ms] time that has to be elapsed before the real unhealthy status is provided
+   */
+  public PendingHealthProvider(HealthProvider delegate, long pendingMs) {
+    this.delegate = delegate;
+    this.pendingMs = pendingMs;
+  }
+
+  @Override
+  public boolean healthy() {
+    boolean healthy = delegate.healthy();
+    if (!healthy) {
+      if (unhealthySince == null) {
+        unhealthySince = Instant.now();
+      }
+      LOG.debug("application unhealthy since {}; health status suppressed until {}", unhealthySince,
+          unhealthySince.plusMillis(pendingMs));
+      if (unhealthySince.plusMillis(pendingMs).isAfter(Instant.now())) {
+        // healthy until delay has expired
+        return true;
+      }
+    } else {
+      if (unhealthySince != null) {
+        LOG.debug("application healthy again (unhealthy for {}s",
+            ChronoUnit.SECONDS.between(unhealthySince, Instant.now()));
+        unhealthySince = null;
+      }
+    }
+    return healthy;
+  }
+}

--- a/jsystemd-spring-boot-starter/src/main/java/com/github/jpmsilva/jsystemd/SystemdNotifyActuatorHealthProvider.java
+++ b/jsystemd-spring-boot-starter/src/main/java/com/github/jpmsilva/jsystemd/SystemdNotifyActuatorHealthProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 TomTom N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jpmsilva.jsystemd;
+
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+
+/**
+ * Implementation of {@link HealthProvider} that provides application health based on Spring Boot Actuator Health Indicators.
+ *
+ * @author Christian Lorenz
+ */
+public class SystemdNotifyActuatorHealthProvider implements SystemdNotifyStatusProvider, HealthProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SystemdNotifyActuatorHealthProvider.class);
+
+  private final List<HealthIndicator> healthIndicators;
+  private final Set<Status> unhealthyStatusCodes;
+
+  /**
+   * @param healthIndicators     Spring Boot Actuator Health Indicators
+   * @param unhealthyStatusCodes list of status codes considered as unhealthy
+   */
+  public SystemdNotifyActuatorHealthProvider(List<HealthIndicator> healthIndicators, Set<Status> unhealthyStatusCodes) {
+    this.healthIndicators = healthIndicators;
+    this.unhealthyStatusCodes = unhealthyStatusCodes;
+    if (this.unhealthyStatusCodes.isEmpty()) {
+      LOG.warn("no status codes considered as unhealthy");
+    } else {
+      LOG.debug("status codes considered as unhealthy={}", unhealthyStatusCodes);
+    }
+  }
+
+  @Override
+  public boolean healthy() {
+    boolean health = healthIndicators.stream().noneMatch(it -> unhealthyStatusCodes.contains(it.health().getStatus()));
+    LOG.debug("application health state={}", health);
+    return health;
+  }
+
+  @Override
+  public String status() {
+    return "health status: " + (healthy() ? "healthy" : "unhealthy");
+  }
+}


### PR DESCRIPTION
* suppress watchdog heartbeat if Spring Boot Actuator health checks are unhealthy => usually triggers restart
* add pending period for unhealthy status (status still pretends to be healthy)